### PR TITLE
post like and unlike updated via js

### DIFF
--- a/src/main/java/com/makersacademy/acebook/controller/PostLikesController.java
+++ b/src/main/java/com/makersacademy/acebook/controller/PostLikesController.java
@@ -4,9 +4,12 @@ import com.makersacademy.acebook.model.User;
 import com.makersacademy.acebook.model.UserService;
 import com.makersacademy.acebook.repository.PostLikeRepository;
 import com.makersacademy.acebook.repository.UserRepository;
+import com.makersacademy.acebook.service.PostLikesService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.Banner;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,6 +17,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Controller
 public class PostLikesController {
@@ -27,19 +31,41 @@ public class PostLikesController {
     @Autowired
     PostLikeRepository postLikeRepository;
 
+    @Autowired
+    PostLikesService postLikesService;
+
 
     @PostMapping("/post/{id}/postlike")
-    public RedirectView createPostLike(@PathVariable Long id){
-        PostLike postLike = new PostLike();
+    public ResponseEntity<Void> createPostLike(@PathVariable Long id){
         String username = userService.getAuthenticatedUserEmail();
         User userDetails = userRepository.findUserByUsername(username)
                 .orElseThrow(() -> new RuntimeException("User not found"));
         Long userId = userDetails.getId();
-        postLike.setUserId(userId);
-        postLike.setCreatedAt(LocalDateTime.now());
-        postLike.setPostId(id);
-        postLikeRepository.save(postLike);
-        return new RedirectView("/posts");
+
+        if (!postLikesService.userHasLikedPost(id, userId)) {
+            PostLike postLike = new PostLike();
+            postLike.setUserId(userId);
+            postLike.setCreatedAt(LocalDateTime.now());
+            postLike.setPostId(id);
+            postLikeRepository.save(postLike);
+        }
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/post/{id}/postunlike")
+    public ResponseEntity<Void> deletePostLike(@PathVariable Long id){
+        String username = userService.getAuthenticatedUserEmail();
+        User userDetails = userRepository.findUserByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        Long userId = userDetails.getId();
+        Optional<PostLike> postLike = postLikesService.getLikeByPostIdAndUserId(id, userId);
+        if (postLike.isPresent() && postLike.get().getUserId().equals(userId)) {
+            Long postLikeId = postLike.get().getId();
+            postLikeRepository.deleteById(postLikeId);
+            return ResponseEntity.ok().build();
+        } else {
+            throw new RuntimeException("Post like not deleted");
+        }
     }
 }
 

--- a/src/main/java/com/makersacademy/acebook/controller/PostsController.java
+++ b/src/main/java/com/makersacademy/acebook/controller/PostsController.java
@@ -1,12 +1,10 @@
 package com.makersacademy.acebook.controller;
 
-import com.makersacademy.acebook.model.Comment;
-import com.makersacademy.acebook.model.Post;
-import com.makersacademy.acebook.model.User;
-import com.makersacademy.acebook.model.UserService;
+import com.makersacademy.acebook.model.*;
 import com.makersacademy.acebook.repository.PostRepository;
 import com.makersacademy.acebook.repository.UserRepository;
 import com.makersacademy.acebook.service.CommentsService;
+import com.makersacademy.acebook.service.PostLikesService;
 import com.makersacademy.acebook.service.PostsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -16,7 +14,6 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -37,11 +34,16 @@ public class PostsController {
     @Autowired
     CommentsService commentsService;
 
+    @Autowired
+    PostLikesService postLikesService;
+
     @GetMapping("/posts")
     public String index(Model model) {
         Iterable<Post> posts = postsService.getPostsInDateOrder();
 
         Map<Long, Iterable<Comment>> postCommentMap = new HashMap<>();
+        Map<Long, Iterable<PostLike>> postLikeMap = new HashMap<>();
+        Map<Long, Boolean> likedPostsMap = new HashMap<>();
 
         User user = userService.getUserProfile();
         model.addAttribute("currentUserId", user.getId());
@@ -50,10 +52,23 @@ public class PostsController {
         model.addAttribute("post", new Post());
         model.addAttribute("comment", new Comment());
         for (Post post: posts) {
+            Iterable<PostLike> postLikes = postLikesService.getLikesByPostId(post.getId());
+            postLikeMap.put(post.getId(), postLikes);
             Iterable<Comment> comments = commentsService.getCommentsByPostId(post.getId());
-            postCommentMap.put(post.getId(),comments);
+            postCommentMap.put(post.getId(), comments);
+
+            boolean isLiked = false;
+            for (PostLike postLike : postLikes) {
+                if (postLike.getUserId().equals(user.getId())) {
+                    isLiked = true;
+                    break;
+                }
+            }
+            likedPostsMap.put(post.getId(), isLiked);
         }
         model.addAttribute("postComments", postCommentMap);
+        model.addAttribute("postLikes", postLikeMap);
+        model.addAttribute("likedPosts", likedPostsMap);
         return "posts/index";
     }
 

--- a/src/main/java/com/makersacademy/acebook/model/PostLike.java
+++ b/src/main/java/com/makersacademy/acebook/model/PostLike.java
@@ -23,6 +23,8 @@ public class PostLike {
         this.createdAt = createdAt;
     }
 
+    public Long getId() { return this.id; };
+
     public Long getUserId(){
         return this.userId;
     }

--- a/src/main/java/com/makersacademy/acebook/repository/PostLikeRepository.java
+++ b/src/main/java/com/makersacademy/acebook/repository/PostLikeRepository.java
@@ -1,7 +1,20 @@
 package com.makersacademy.acebook.repository;
 
+import com.makersacademy.acebook.model.Comment;
 import com.makersacademy.acebook.model.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    @Query(value = "SELECT * FROM post_likes WHERE post_id = :postId",nativeQuery = true)
+    List<PostLike> searchByPostId(@Param("postId") Long postId);
+
+    @Query(value = "SELECT * FROM post_likes WHERE post_id = :postId AND user_id = :userId",nativeQuery = true)
+    Optional<PostLike> searchByPostIdAndUserId(@Param("postId") Long postId, @Param("userId") Long userId);
+
+    boolean existsByPostIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/com/makersacademy/acebook/service/PostLikesService.java
+++ b/src/main/java/com/makersacademy/acebook/service/PostLikesService.java
@@ -1,0 +1,26 @@
+package com.makersacademy.acebook.service;
+
+import com.makersacademy.acebook.model.PostLike;
+import com.makersacademy.acebook.repository.PostLikeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class PostLikesService {
+    @Autowired
+    PostLikeRepository postLikeRepository;
+
+    public Iterable<PostLike> getLikesByPostId(Long postId) {
+        return postLikeRepository.searchByPostId(postId);
+    }
+
+    public Optional<PostLike> getLikeByPostIdAndUserId(Long postId, Long userId) {
+        return postLikeRepository.searchByPostIdAndUserId(postId, userId);
+    }
+
+    public boolean userHasLikedPost(Long postId, Long userId) {
+        return postLikeRepository.existsByPostIdAndUserId(postId, userId);
+    }
+}

--- a/src/main/java/com/makersacademy/acebook/service/PostsService.java
+++ b/src/main/java/com/makersacademy/acebook/service/PostsService.java
@@ -1,6 +1,8 @@
 package com.makersacademy.acebook.service;
 
 import com.makersacademy.acebook.model.Post;
+import com.makersacademy.acebook.model.PostLike;
+import com.makersacademy.acebook.repository.PostLikeRepository;
 import com.makersacademy.acebook.repository.PostRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
@@ -10,6 +12,9 @@ import org.springframework.stereotype.Service;
 public class PostsService {
     @Autowired
     PostRepository postRepository;
+
+    @Autowired
+    PostLikeRepository postLikeRepository;
 
     public Iterable<Post> getPostsInDateOrder() {
         return postRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"));

--- a/src/main/resources/static/css/posts.css
+++ b/src/main/resources/static/css/posts.css
@@ -1,3 +1,8 @@
 .posts_container {
     max-width: 32rem;
 }
+
+.post_like_button {
+    all: unset;
+    color: var(--acebook-blue);
+}

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -1,0 +1,29 @@
+document.addEventListener("DOMContentLoaded", function() {
+    postLikeButtons = document.querySelectorAll(".post_like_button");
+    testLike = document.querySelector(".posts_header");
+
+    postLikeButtons.forEach(button => {
+        button.addEventListener("click", toggleLike);
+    });
+
+    function toggleLike(e) {
+        e.preventDefault();
+        const postId = this.dataset.postId;
+        const isLiked = this.dataset.liked === "true";
+        const icon = this.querySelector('i');
+        const likeCountElement = document.querySelector(`#like_count_${postId}`);
+        console.log(likeCountElement);
+        fetch(`/post/${postId}/` + (isLiked ? 'postunlike' : 'postlike'), {
+            method: isLiked ? 'DELETE' : 'POST'
+        }).then(response => {
+            if (response.ok) {
+                this.dataset.liked = (!isLiked).toString();
+                icon.classList.toggle('fa-solid', !isLiked);
+                icon.classList.toggle('fa-regular', isLiked);
+
+                let currentLikeCount = parseInt(likeCountElement.textContent);
+                likeCountElement.textContent = isLiked ? currentLikeCount - 1 : currentLikeCount + 1;
+            }
+        });
+    }
+});

--- a/src/main/resources/templates/posts/index.html
+++ b/src/main/resources/templates/posts/index.html
@@ -11,6 +11,7 @@
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">
+        <script src="/js/main.js" defer></script>
     </head>
     <body>
         <div th:insert="fragments/nav :: navigation"></div>
@@ -33,9 +34,16 @@
 <!--                    <p th:text="${post.photo_url}"></p>-->
                     <p th:text="${post.content}"></p>
                     <p th:text="${post.createdAt}"></p>
-                    <form action="#" th:action="@{/post/{id}/postlike(id=${post.id})}" th:object="${postLike}" method="post">
-                        <input type="submit" value="Like"/>
-                    </form>
+
+                    <div>
+                        <button class="post_like_button clickable"
+                                th:data-post-id="${post.id}"
+                                th:data-liked="${likedPosts[post.id]}">
+                            <i class="fa" th:class="${likedPosts[post.id]} ? 'fa-solid fa-thumbs-up' : 'fa-regular fa-thumbs-up'"></i>
+                        </button>
+                        <div th:text="${postLikes[post.Id].size()}" th:id="'like_count_' + ${post.id}" class="post_like_count"></div>
+                    </div>
+
                     <form th:if="${post.userId == currentUserId}" action="#" th:action="@{/post/{id}(id=${post.id})}" th:method="delete">
                         <input type="submit" value="Delete"/>
                     </form>
@@ -55,6 +63,5 @@
                 </div>
             </div>
         </div>
-
     </body>
 </html>


### PR DESCRIPTION
Features:
-number of likes for each post visible on page
-users can unlike a post they have already liked


Changes made:

Main.js
-button clicks on like handled by js so that page doesn't have to be refreshed to see changes
-button toggles between solid and unfilled thumbs up
-functionality of button also toggles between like and unlike
-like counter updates without page refresh too

PostLikesController
-adds new postlike to the db and returns HTTP 200 OK response
-removes postlike from the db and returns HTTP 200 OK response

PostsConstroller
-likedPostsMap generated and sent to html
-is a record of which posts the current logged in user has already liked

PostLikeService/Repo
-query to db based on post id to get number of likes per post
-query to db based on post id and user id to get corresponding postlike id
-query to db to check if a user has liked a post previously

HTML
-postlike thumbs up button conditionally rendered depending on if current user has already liked it previously