### PR TITLE
notifications page with links and read functionality

### DIFF
--- a/src/main/java/com/makersacademy/acebook/controller/NotificationsController.java
+++ b/src/main/java/com/makersacademy/acebook/controller/NotificationsController.java
@@ -12,7 +12,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.view.RedirectView;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Controller
 public class NotificationsController {
@@ -37,11 +42,41 @@ public class NotificationsController {
         Long userId = userDetails.getId();
 
         Iterable<Notification> allNotificationsForUser = notificationsService.getNotificationsForUser(userId);
+        Iterable<Notification> allUnreadNotificationsForUser = notificationsService.getUnreadNotificationsForUser(userId);
+
+        Map<Long, String> redirectMap = new HashMap<>();
+        for (Notification notification : allUnreadNotificationsForUser) {
+            String redirectUrl = "";
+            String type = notification.getType();
+
+            if (type.equals("like") || type.equals("comment")) {
+                redirectUrl += "/post/" + notification.getPostId();
+            } else if (type.equals("friend_request")) {
+                redirectUrl += "/friends";
+            } else if (type.equals("message")) {
+                redirectUrl += "/chats" + notification.getChatId();
+            } else {
+                redirectUrl += "/posts";
+            }
+
+            redirectMap.put(notification.getId(), redirectUrl);
+        }
 
         model.addAttribute("notifications", allNotificationsForUser);
+        model.addAttribute("unreadNotifications", allUnreadNotificationsForUser);
         model.addAttribute("currentUserId", userId);
         model.addAttribute("currentUser", user);
+        model.addAttribute("redirectMap", redirectMap);
         model.addAttribute("post", new Post());
         return "notifications/index";
+    }
+
+    @PostMapping("/notifications/{id}")
+    public RedirectView readNotification(@PathVariable Long id) {
+        Notification notification = notificationRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Notification not found"));
+        notification.setIsRead(true);
+        notificationRepository.save(notification);
+        return new RedirectView("/notifications");
     }
 }

--- a/src/main/java/com/makersacademy/acebook/repository/NotificationRepository.java
+++ b/src/main/java/com/makersacademy/acebook/repository/NotificationRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     Iterable<Notification> findByReceiverId(Long receiverId);
+
+    Iterable<Notification> findByReceiverIdAndIsReadFalse(Long receiverId);
 }

--- a/src/main/java/com/makersacademy/acebook/service/NotificationsService.java
+++ b/src/main/java/com/makersacademy/acebook/service/NotificationsService.java
@@ -13,4 +13,8 @@ public class NotificationsService {
     public Iterable<Notification> getNotificationsForUser(Long userId) {
         return notificationRepository.findByReceiverId(userId);
     }
+
+    public Iterable<Notification> getUnreadNotificationsForUser(Long userId) {
+        return notificationRepository.findByReceiverIdAndIsReadFalse(userId);
+    }
 }

--- a/src/main/resources/static/css/notifications.css
+++ b/src/main/resources/static/css/notifications.css
@@ -1,0 +1,31 @@
+.notifications_container {
+    max-width: 32rem;
+    margin: 4rem auto;
+    gap: 1rem;
+}
+
+.notification_card {
+    position: relative;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.notification_read {
+    all: unset;
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    color: var(--acebook-blue);
+}
+
+.notification_content {
+    max-width: 90%;
+}
+
+.notifications_msg {
+    text-align: center;
+}
+
+.notification_card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
+}

--- a/src/main/resources/templates/notifications/index.html
+++ b/src/main/resources/templates/notifications/index.html
@@ -16,10 +16,25 @@
 </head>
 <body>
   <div th:insert="fragments/nav :: navigation(${currentUserId})"></div>
-  <h1>Notifications</h1>
-  <div th:each="notification: ${notifications}">
-    <div th:text="${notification.content}"></div>
+
+  <div class="results-container notifications_container">
+
+    <div th:if="${unreadNotifications.isEmpty()}" class="notifications_msg">
+      <p>No unread notifications.</p>
+    </div>
+
+    <div th:each="notification: ${unreadNotifications}">
+      <div class="card post_card notification_card">
+        <form th:action="@{/notifications/{id}(id=${notification.id})}" method="post">
+          <button type="submit" class="fa-regular fa-circle-xmark notification_read clickable"></button>
+        </form>
+        <a th:href="${redirectMap[notification.id]}"><div th:text="${notification.content}" class="notification_content clickable"></div></a>
+
+      </div>
+    </div>
+
   </div>
+
   <div th:insert="posts/new_post :: newPost"></div>
 </body>
 </html>


### PR DESCRIPTION
Notifications page
-displays only unread notifications
-card for each notification
-cross button to mark notification as read
-card links to post/message/friend that it relates to

Notes: 
-doesn't work for /friends - is this path working on the main or is it on another branch?
-doesn't work for /messages as this is being worked on in separate PR